### PR TITLE
Fixed bug in FindBestResultKernel

### DIFF
--- a/enigma-cuda-lib/cuda_code.cu
+++ b/enigma-cuda-lib/cuda_code.cu
@@ -690,6 +690,15 @@ void SetUpResultsMemory(int count)
   CUDA_CHECK(cudaMalloc((void**)&h_task.results, count * sizeof(Result)));
 }
 
+__device__ void SelectHigherScore0(Result & a, const Result & b, unsigned int bindex)
+{
+  if (b.score > a.score)
+  {
+    a.index = bindex;
+    a.score = b.score;
+  }
+}
+
 __device__ void SelectHigherScore(Result & a, const Result & b)
 {
   if (b.score > a.score)
@@ -710,12 +719,17 @@ __global__ void FindBestResultKernel(Result *g_idata, Result *g_odata,
   Result best_pair;
   if (i < count)
   {
-    best_pair.index = g_idata[i].index;
+    best_pair.index = i;
     best_pair.score = g_idata[i].score;
   }
-  else best_pair.score = 0;
+  else
+  {
+    best_pair.index = count - 1;
+    best_pair.score = g_idata[count-1].score;
+  }
 
-  if (i + blockDim.x < count) SelectHigherScore(best_pair, g_idata[i + blockDim.x]);
+  if (i + blockDim.x < count)
+    SelectHigherScore0(best_pair, g_idata[i + blockDim.x], i + blockDim.x);
 
   sdata[tid] = best_pair;
   __syncthreads();

--- a/enigma-cuda-lib/cuda_code.cuh
+++ b/enigma-cuda-lib/cuda_code.cuh
@@ -55,6 +55,8 @@ extern "C"
     __device__
     void TriScore(Block & block, const int8_t * scrambling_table);
     __device__ 
+    void SelectHigherScore0(Result & a, const Result & b, unsigned int bindex);
+    __device__ 
     void SelectHigherScore(Result & a, const Result & b);
     __device__ 
     void TrySwap(int8_t i, int8_t k,


### PR DESCRIPTION
I found bug in FindBestResultKernel. Due to accessing beyond array bounds and wrong element indexing after first call in GetBestResult this kernel can get wrong unexpected results. I apply similar patch to my OpenCL version.